### PR TITLE
video result analysis endpoint and bugfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@google-cloud/storage": "^7.11.2",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
+        "csv-parse": "^5.5.6",
         "dotenv": "^16.4.5",
         "ejs": "^3.1.3",
         "express": "^4.17.1",
@@ -576,6 +577,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.6.tgz",
+      "integrity": "sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A=="
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -2891,6 +2897,11 @@
         "object-assign": "^4",
         "vary": "^1"
       }
+    },
+    "csv-parse": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.6.tgz",
+      "integrity": "sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A=="
     },
     "debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@google-cloud/storage": "^7.11.2",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
+    "csv-parse": "^5.5.6",
     "dotenv": "^16.4.5",
     "ejs": "^3.1.3",
     "express": "^4.17.1",

--- a/src/controllers/videoResultController.js
+++ b/src/controllers/videoResultController.js
@@ -146,4 +146,28 @@ module.exports.videoResult_patch = async (req, res) => {
   }
 };
 
-module.exports.videoResult_analysis = async (req, res) => {};
+module.exports.videoResultAnalysis = async (req, res) => {
+  const id = req.params.id;
+
+  const videoResult = await VideoResultService.getVideoResult(id);
+
+  if (videoResult === null) {
+    res
+      .status(404)
+      .json(
+        new ResponseDto(
+          false,
+          null,
+          "Video result with the given id not exists"
+        )
+      );
+  }
+
+  const responseData = await VideoResultService.getVideoResultAnalysis(
+    videoResult
+  );
+
+  res
+    .status(200)
+    .json(new ResponseDto(true, responseData, "Successfully get video result"));
+};

--- a/src/controllers/videoResultController.js
+++ b/src/controllers/videoResultController.js
@@ -2,21 +2,20 @@ const ResponseDto = require("../models/dto/response/ResponseDto");
 const VideoResultService = require("../services/videoResultService");
 const initiateVideoResultSchema = require("../validations/InitiateVideoResultSchema");
 const UpdateVideoResultSchmea = require("../validations/UpdateVideoResultSchema");
-const jwt = require("jsonwebtoken");
 
 module.exports.videoResultFilePathFromModel_post = (req, res) => {};
 
-module.exports.initateVideoResultRecord_post = (req, res) => {
+module.exports.initateVideoResultRecord_post = async (req, res) => {
   try {
     const result = initiateVideoResultSchema.validate(req.body);
     if (result.error) {
       return res.status(400).json({ error: result.error.details[0].message });
     }
-    const dataResponse = VideoResultService.initiateVideoResult(
+
+    const dataResponse = await VideoResultService.initiateVideoResult(
       req.body.videoName,
       req.body.inspectionDate,
       req.body.inspectorName,
-      req.body.uuid,
       req.headers.authorization
     );
     return res
@@ -146,3 +145,5 @@ module.exports.videoResult_patch = async (req, res) => {
       .json(new ResponseDto(false, e, "Failed to update video result"));
   }
 };
+
+module.exports.videoResult_analysis = async (req, res) => {};

--- a/src/routes/videoResultRoute.js
+++ b/src/routes/videoResultRoute.js
@@ -18,4 +18,5 @@ router.post(
   videoResultController.initateVideoResultRecord_post
 );
 
+router.get("/:id/analysis", videoResultController.videoResultAnalysis);
 module.exports = router;

--- a/src/services/cloudStorageService.js
+++ b/src/services/cloudStorageService.js
@@ -13,8 +13,21 @@ const uploadFile = async (file, bucket, destination) => {
   return url;
 };
 
-const uploadCsv = async (file) => {
-  return await uploadFile(file, "eci_matagaruda_bucket", `csv/${uuidv4()}.csv`);
+const uploadCsv = async (file, videoResultId) => {
+  return await uploadFile(
+    file,
+    "eci_matagaruda_bucket",
+    `csv/${videoResultId}.csv`
+  );
 };
 
-module.exports = { uploadCsv };
+const getCsvContent = async (fileName) => {
+  const [file] = await storage
+    .bucket("eci_matagaruda_bucket")
+    .file("csv/" + fileName + ".csv")
+    .download();
+  return file.toString();
+};
+
+
+module.exports = { uploadCsv, getCsvContent };

--- a/src/services/videoResultService.js
+++ b/src/services/videoResultService.js
@@ -23,7 +23,7 @@ class VideoResultService {
       videoName,
       inspectionDate,
       inspectorName,
-      detectionStatus: "pending",
+      detectionStatus: "SUBMITTED",
       userId: decoded.id,
     });
     return videoResult;

--- a/src/services/videoResultService.js
+++ b/src/services/videoResultService.js
@@ -1,38 +1,32 @@
 const videoResultModel = require("../models").VideoResult;
 const { Op } = require("sequelize");
 const { uploadCsv } = require("./cloudStorageService");
+const jwt = require("jsonwebtoken");
+const { v4: uuidv4 } = require("uuid");
 
 class VideoResultService {
   constructor(videoResultModel) {
     this.videoResultModel = videoResultModel;
   }
 
-  initiateVideoResult(
+  async initiateVideoResult(
     videoName,
     inspectionDate,
     inspectorName,
-    uuid,
     bearerToken
   ) {
     const token = bearerToken.split(" ")[1];
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    const videoResult = videoResultModel.create({
-      id: uuid,
+    const idVideoResult = uuidv4();
+    const videoResult = await videoResultModel.create({
+      id: idVideoResult,
       videoName,
       inspectionDate,
       inspectorName,
       detectionStatus: "pending",
       userId: decoded.id,
     });
-    return res
-      .status(201)
-      .json(
-        new ResponseDto(
-          true,
-          videoResult,
-          "Video result initiated successfully"
-        )
-      );
+    return videoResult;
   }
 
   async getAllVideoResult(needVerificationOnly = false) {

--- a/src/validations/InitiateVideoResultSchema.js
+++ b/src/validations/InitiateVideoResultSchema.js
@@ -4,7 +4,7 @@ const initiateVideoResultSchema = Joi.object({
   videoName: Joi.string().required(),
   inspectionDate: Joi.date().required(),
   inspectorName: Joi.string().required(),
-  uuid: Joi.string().required(),
+  // uuid: Joi.string().required(),
 });
 
 module.exports = initiateVideoResultSchema;


### PR DESCRIPTION
### Changes
#### `/videoResult/initiateVideoResultRecord` endpoint
- fix bug when videoResult object successfully created but still giving fail response
- change request body. now request body does not need to include uuid
**new req body **
```
{
    "inspectionDate": "",
    "videoName": "contoh",
    "inspectorName":"Jarip"
}
```
- change uploadCsv function. Use videoResult.id as a filename for the uploaded csv
#### `/videoResult/:videoResultId/analysis`
- create API endpoint to get videoResult analysis
**Example response:**
```
{
    "success": true,
    "data": {
        "downloadUrl": "https://storage.googleapis.com/eci_matagaruda_bucket/csv/a3e976c6-07fa-4335-858e-efe41f5d1547.csv",
        "roadCondition": {
            "undamaged": 2055,
            "mildDamage": 486,
            "moderateDamage": 3,
            "severeDamage": 1
        },
        "totalVolumeCrack": {
            "pothole": 44.373,
            "alligator": 0,
            "longAndLatCrack": 15124.919999999993
        },
        "maintenanceCostEstimation": 463065930,
        "numberOfCrack": {
            "pothole": 11,
            "alligator": 0,
            "lateralCrack": 241,
            "longitudinalCrack": 2494
        }
    },
    "message": "Successfully get video result"
}
```